### PR TITLE
[SECURITY] Fix Temporary Directory Hijacking or Information Disclosure Vulnerability


### DIFF
--- a/core/src/main/java/net/adoptopenjdk/icedteaweb/client/parts/about/AboutDialog.java
+++ b/core/src/main/java/net/adoptopenjdk/icedteaweb/client/parts/about/AboutDialog.java
@@ -58,6 +58,7 @@ import java.awt.event.ActionListener;
 import java.io.File;
 import java.io.IOException;
 import java.net.URL;
+import java.nio.file.Files;
 import java.util.Locale;
 
 import static net.adoptopenjdk.icedteaweb.i18n.Translator.R;
@@ -190,9 +191,7 @@ public final class AboutDialog extends JPanel implements Runnable, ActionListene
             if (helpPanel == null) {
                 //copy logo and generate resources to tmp dir
                 try {
-                    File f = File.createTempFile("icedtea-web", "help");
-                    f.delete();
-                    f.mkdir();
+                    File f = Files.createTempDirectory("icedtea-web" + "help").toFile();
                     f.deleteOnExit();
                     TextsProvider.generateRuntimeHtmlTexts(f);
                     //detect running application

--- a/core/src/main/java/net/adoptopenjdk/icedteaweb/config/validators/DirectoryValidator.java
+++ b/core/src/main/java/net/adoptopenjdk/icedteaweb/config/validators/DirectoryValidator.java
@@ -12,6 +12,7 @@ import net.sourceforge.jnlp.runtime.JNLPRuntime;
 import net.sourceforge.jnlp.util.FileUtils;
 
 import java.io.File;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -97,7 +98,7 @@ public class DirectoryValidator {
         File testFile = null;
         boolean correctPermissions = true;
         try {
-            testFile = File.createTempFile("maindir", "check", f);
+            testFile = Files.createTempDirectory(f.toPath(), "maindir" + "check").toFile();
             if (!testFile.exists()) {
                 correctPermissions = false;
             }
@@ -117,11 +118,10 @@ public class DirectoryValidator {
             if (canList == null || canList.length == 0) {
                 correctPermissions = false;
             }
-            testFile.delete();
             if (testFile.exists()) {
                 correctPermissions = false;
             } else {
-                final boolean created = testFile.mkdir();
+                final boolean created = true;
                 if (!created) {
                     correctPermissions = false;
                 }

--- a/core/src/test/java/net/sourceforge/jnlp/cache/CacheLRUWrapperTest.java
+++ b/core/src/test/java/net/sourceforge/jnlp/cache/CacheLRUWrapperTest.java
@@ -47,6 +47,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.PrintStream;
+import java.nio.file.Files;
 import java.util.concurrent.CountDownLatch;
 
 import static net.adoptopenjdk.icedteaweb.JvmPropertyConstants.JAVA_IO_TMPDIR;
@@ -64,9 +65,7 @@ public class CacheLRUWrapperTest {
 
     static {
         try {
-            tmpCache = File.createTempFile("itw", "CacheLRUWrapperTest", javaTmp);
-            tmpCache.delete();
-            tmpCache.mkdir();
+            tmpCache = Files.createTempDirectory(javaTmp.toPath(), "itw" + "CacheLRUWrapperTest").toFile();
             tmpCache.deleteOnExit();
             if (!tmpCache.isDirectory()) {
                 throw new IOException("Unsuccessful to create tmpfile, remove it and create same directory");

--- a/core/src/test/java/net/sourceforge/jnlp/config/DeploymentConfigurationTest.java
+++ b/core/src/test/java/net/sourceforge/jnlp/config/DeploymentConfigurationTest.java
@@ -52,6 +52,7 @@ import javax.naming.ConfigurationException;
 import java.io.File;
 import java.io.IOException;
 import java.net.URL;
+import java.nio.file.Files;
 import java.util.Date;
 import java.util.Map;
 import java.util.Properties;
@@ -235,9 +236,7 @@ public class DeploymentConfigurationTest extends NoStdOutErrTest {
     @Test
     public void testCheckUrlRemoteNotOk404_1() throws ConfigurationException, IOException {
         ServerLauncher server = ServerAccess.getIndependentInstance(System.getProperty(JAVA_IO_TMPDIR), ServerAccess.findFreePort());
-        File f = File.createTempFile("itw", "checkUrlTest_404");
-        f.delete();
-        f.mkdir();
+        File f = Files.createTempDirectory("itw" + "checkUrlTest_404").toFile();
         f.deleteOnExit();
         try {
             URL u = new URL("http://localhost:" + server.getPort() + "/" + f.getName() + "/notexisting.file");

--- a/core/src/test/java/net/sourceforge/jnlp/config/DirectoryValidatorTest.java
+++ b/core/src/test/java/net/sourceforge/jnlp/config/DirectoryValidatorTest.java
@@ -47,6 +47,7 @@ import org.junit.Test;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.util.Arrays;
 
 import static org.junit.Assert.assertTrue;
@@ -239,10 +240,8 @@ public class DirectoryValidatorTest extends NoStdOutErrTest{
         assertTrue(s4.isEmpty());
 
         File f3 = File.createTempFile("test", "testMainDirs", f2);
-        File f4 = File.createTempFile("test", "testMainDirs", f2);
-        assertTrue(f4.delete());
-        assertTrue(f3.delete()); 
-        assertTrue(f4.mkdir());
+        File f4 = Files.createTempDirectory(f2.toPath(), "test" + "testMainDirs").toFile();
+        assertTrue(f3.delete());
         assertTrue(f2.setWritable(false)); //now f2 will not be recreated
         
         dv= new DirectoryValidator(Arrays.asList(f3, f4));
@@ -260,9 +259,7 @@ public class DirectoryValidatorTest extends NoStdOutErrTest{
     }
 
     private File createTempDir() throws IOException {
-        File f1 = File.createTempFile("test", "testMainDirs");
-        assertTrue(f1.delete());
-        assertTrue(f1.mkdir());
+        File f1 = Files.createTempDirectory("test" + "testMainDirs").toFile();
         f1.deleteOnExit();
         return f1;
     }

--- a/test-extensions/src/main/java/net/adoptopenjdk/icedteaweb/testing/browsertesting/browsers/firefox/FirefoxProfilesOperator.java
+++ b/test-extensions/src/main/java/net/adoptopenjdk/icedteaweb/testing/browsertesting/browsers/firefox/FirefoxProfilesOperator.java
@@ -45,6 +45,7 @@ import java.io.FileOutputStream;
 import java.io.FilenameFilter;
 import java.io.IOException;
 import java.nio.channels.FileChannel;
+import java.nio.file.Files;
 
 import static net.adoptopenjdk.icedteaweb.JvmPropertyConstants.USER_HOME;
 
@@ -65,9 +66,7 @@ public class FirefoxProfilesOperator {
             return;
         }
         sourceDir = new File(System.getProperty(USER_HOME) + "/.mozilla/firefox/");
-        final File f = File.createTempFile("backupedFirefox_", "_profiles.default");
-        f.delete();
-        f.mkdir();
+        final File f = Files.createTempDirectory("backupedFirefox_" + "_profiles.default").toFile();
         backupDir = f;
         final String message = "Backuping firefox profiles from " + sourceDir.getAbsolutePath() + " to " + backupDir.getAbsolutePath();
         ServerAccess.logOutputReprint(message);

--- a/test-extensions/src/main/java/net/adoptopenjdk/icedteaweb/testing/util/FileTestUtils.java
+++ b/test-extensions/src/main/java/net/adoptopenjdk/icedteaweb/testing/util/FileTestUtils.java
@@ -48,6 +48,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.lang.management.ManagementFactory;
+import java.nio.file.Files;
 import java.util.jar.Attributes;
 import java.util.jar.JarEntry;
 import java.util.jar.JarOutputStream;
@@ -134,13 +135,7 @@ public class FileTestUtils {
     /* Creates a temporary directory. Note that Java 7 has a method for this,
      * but we want to remain 6-compatible. */
     static public File createTempDirectory() throws IOException {
-        final File file = File.createTempFile("temp",
-                Long.toString(System.nanoTime()));
-        file.delete();
-        if (!file.mkdir()) {
-            throw new IOException("Failed to create temporary directory '"
-                    + file + "' for test.");
-        }
+        final File file = Files.createTempDirectory("temp" + Long.toString(System.nanoTime())).toFile();
         return file;
     }
 


### PR DESCRIPTION

# Security Vulnerability Fix

This pull request fixes either 1.) Temporary Directory Hijacking Vulnerability, or 2.) Temporary Directory Information Disclosure Vulnerability, which existed in this project.

## Preamble

The system temporary directory is shared between all users on most unix-like systems (not MacOS, or Windows). Thus, code interacting with the system temporary directory must be careful about file interactions in this directory, and must ensure that the correct file permissions are set.

This PR was generated because the following chain of calls was detected in this repository in a way that leaves this project vulnerable.
`File.createTempFile(..)` -> `file.delete()` -> either `file.mkdir()` or `file.mkdirs()`.

### Impact

This vulnerability can have one of two impacts depending upon which vulnerability it is.

 1. Temporary Directory Information Disclosure - Information in this directory is visable to other local users, allowing a malicious actor co-resident on the same machine to view potentially sensitive files.
 2. Temporary Directory Hijacking Vulnerability - Same impact as 1. above, but also, ther local users can manipulate/add contents to this directory. If code is being executed out of this temporary directory, it can lead to local priviledge escalation.

## Temporary Directory Hijacking

This vulnerability exists because the return value from `file.mkdir()` or `file.mkdirs()` is not checked to determine if the call succeeded. Say, for example, because another local user created the directory before this process.

```java
File tmpDir = File.createTempFile("temp", ".dir"); // Attacker knows the full path of the directory that will be later created
// delete the file that was created
tmpDir.delete(); // Attacker sees file is deleted and begins a race to create their own directory before the java code.
// and makes a directory of the same name
// SECURITY VULNERABILITY: Race Condition! - Attacker beats java code and now owns this directory
tmpDir.mkdirs(); // This method returns 'false' because it was unable to create the directory. No exception is thrown.
// Attacker can write any new files to this directory that they wish.
// Attacker can read any files created within this directory.
```

### Other Examples

 - [CVE-2021-20202](https://github.com/advisories/GHSA-6xp6-fmc8-pmmr) - Keycloak/Keycloak
 - [CVE-2020-27216](https://github.com/advisories/GHSA-g3wg-6mcf-8jj6) - eclipse/jetty.project

## Temporary Directory Information Disclosure

This vulnerability exists because, although the return values of `file.mkdir()` or `file.mkdirs()` are correctly checked, the permissions of the directory that is created follows the default system `uname` settings. Thus, the directory is created with everyone-readable permissions. As such, any files/directories written into this directory are viewable by all other local users on the system.

```java
File tmpDir = File.createTempFile("temp", ".dir");
tmpDir.delete();
if (!tmpDir.mkdirs()) { // Guard correctly prevents temporary directory hijacking, but directory contents are everyone-readable.
    throw new IOException("Failed to create temporary directory");
}
```

### Other Examples

 - [CVE-2020-15250](https://github.com/advisories/GHSA-269g-pwp5-87pp) - junit-team/junit
 - [CVE-2021-21364](https://github.com/advisories/GHSA-hpv8-9rq5-hq7w) - swagger-api/swagger-codegen
 - [CVE-2022-24823](https://github.com/advisories/GHSA-5mcr-gq6c-3hq2) - netty/netty
 - [CVE-2022-24823](https://github.com/advisories/GHSA-269q-hmxg-m83q) - netty/netty

# The Fix

The fix has been to convert the logic above to use the following API that was introduced in Java 1.7.

```java
File tmpDir = Files.createTempDirectory("temp dir").toFile();
```

The API both created the directory securely, ie with a random, non-conflicting name, with directory permissions that only allow the currently executing user to read or write the contents of this directory.

# :arrow_right: Vulnerability Disclosure :arrow_left:

:wave: Vulnerability disclosure is a super important part of the vulnerability handling process and should not be skipped! This may be completely new to you, and that's okay, I'm here to assist!

First question, do we need to perform vulnerability disclosure? It depends!

 1. Is the vulnerable code only in tests or example code? No disclosure required!
 2. Is the vulnerable code in code shipped to your end users? Vulnerability disclosure is probably required!

## Vulnerability Disclosure How-To

You have a few options options to perform vulnerability disclosure. However, I'd like to suggest the following 2 options:

 1. Request a CVE number from GitHub by creating a repository-level [GitHub Security Advisory](https://docs.github.com/en/code-security/repository-security-advisories/creating-a-repository-security-advisory). This has the advantage that, if you provide sufficient information, GitHub will automatically generate Dependabot alerts for your downstream consumers, resolving this vulnerability more quickly.
 2. Reach out to the team at Snyk to assist with CVE issuance. They can be reached at the [Snyk's Disclosure Email](mailto:report@snyk.io).

## Detecting this and Future Vulnerabilities

This vulnerability was automatically detected by GitHub's [LGTM.com](https://lgtm.com) using this [CodeQL Query](https://lgtm.com/rules/1515014784717/).

You can automatically detect future vulnerabilities like this by enabling the free (for open-source) [GitHub Action](https://github.com/github/codeql-action).

I'm not an employee of GitHub, I'm simply an open-source security researcher.

## Source

This contribution was automatically generated with an [OpenRewrite](https://github.com/openrewrite/rewrite) [refactoring recipe](https://docs.openrewrite.org/), which was lovingly hand crafted to bring this security fix to your repository.

The source code that generated this PR can be found here:
[UseFilesCreateTempDirectory](https://github.com/openrewrite/rewrite-java-security/blob/main/src/main/java/org/openrewrite/java/security/UseFilesCreateTempDirectory.java)

## Opting-Out

If you'd like to opt-out of future automated security vulnerability fixes like this, please consider adding a file called
`.github/GH-ROBOTS.txt` to your repository with the line:

```
User-agent: JLLeitschuh/security-research
Disallow: *
```

This bot will respect the [ROBOTS.txt](https://moz.com/learn/seo/robotstxt) format for future contributions.

Alternatively, if this project is no longer actively maintained, consider [archiving](https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-archiving-repositories) the repository.

## CLA Requirements

_This section is only relevant if your project requires contributors to sign a Contributor License Agreement (CLA) for external contributions._

It is unlikely that I'll be able to directly sign CLAs. However, all contributed commits are already automatically signed-off.

> The meaning of a signoff depends on the project, but it typically certifies that committer has the rights to submit this work under the same license and agrees to a Developer Certificate of Origin 
> (see [https://developercertificate.org/](https://developercertificate.org/) for more information).
>
> \- [Git Commit Signoff documentation](https://developercertificate.org/)

If signing your organization's CLA is a strict-requirement for merging this contribution, please feel free to close this PR.

## Sponsorship & Support

This contribution is sponsored by HUMAN Security Inc. and the new Dan Kaminsky Fellowship, a fellowship created to celebrate Dan's memory and legacy by funding open-source work that makes the world a better (and more secure) place.

This PR was generated by [Moderne](https://www.moderne.io/), a free-for-open source SaaS offering that uses format-preserving AST transformations to fix bugs, standardize code style, apply best practices, migrate library versions, and fix common security vulnerabilities at scale.

## Tracking

All PR's generated as part of this fix are tracked here: https://github.com/JLLeitschuh/security-research/issues/10
